### PR TITLE
WTES-29: JUnit 5 extension for AemContext

### DIFF
--- a/aem-mock/pom.xml
+++ b/aem-mock/pom.xml
@@ -125,7 +125,7 @@
       <artifactId>oak-jcr</artifactId>
       <scope>compile</scope>
     </dependency>
-      
+
     <!-- Has to be put first in dependencies to make sure updates oak/jcr dependencies
          are loaded before AEM API deps -->
     <dependency>
@@ -271,10 +271,17 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.0.2</version>
       <scope>compile</scope>
     </dependency>
 
@@ -284,9 +291,9 @@
       <version>${logging-mock.version}</version>
       <scope>test</scope>
     </dependency>
-    
+
   </dependencies>
-  
+
   <dependencyManagement>
     <dependencies>
 
@@ -338,7 +345,7 @@
     </plugins>
     <pluginManagement>
       <plugins>
-      
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -346,6 +353,20 @@
             <!-- Travis build workaround, see https://github.com/travis-ci/travis-ci/issues/3396 -->
             <argLine>-Xmx1024m -XX:MaxPermSize=512M</argLine>
           </configuration>
+
+
+          <dependencies>
+            <dependency>
+              <groupId>org.junit.platform</groupId>
+              <artifactId>junit-platform-surefire-provider</artifactId>
+              <version>1.0.1</version>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter-engine</artifactId>
+              <version>5.0.1</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
       </plugins>

--- a/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/AemContext.java
+++ b/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/AemContext.java
@@ -1,0 +1,15 @@
+package io.wcm.testing.mock.aem.junit5;
+
+import io.wcm.testing.mock.aem.context.AemContextImpl;
+
+public abstract class AemContext extends AemContextImpl {
+
+    protected void setUpContext() {
+        super.setUp();
+    }
+
+    protected void tearDownContext() {
+        super.tearDown();
+    }
+
+}

--- a/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/AemContextExtension.java
+++ b/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/AemContextExtension.java
@@ -1,0 +1,111 @@
+package io.wcm.testing.mock.aem.junit5;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+import static java.util.Collections.emptyList;
+
+public class AemContextExtension implements ParameterResolver, AfterEachCallback {
+
+    private static final Namespace AEM_CONTEXT_NAMESPACE = Namespace.create(AemContextExtension.class);
+    private static final Class<ResourceResolverMockAemContext> DEFAULT_AEM_CONTEXT_TYPE = ResourceResolverMockAemContext.class;
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return AemContext.class.isAssignableFrom(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        AemContext aemContext = getAemContext(extensionContext);
+        if (aemContext == null) {
+            aemContext = createAndStoreAemContext(parameterContext, extensionContext);
+        } else if (paramIsNotInstanceOfExistingContext(parameterContext, aemContext)) {
+            throw new ParameterResolutionException(
+                    "Found AemContext instance of type: " + aemContext.getClass().getName() + "\n"
+                            + "Required is: " + parameterContext.getParameter().getType().getName() + "\n"
+                            + "Verify that all test lifecycle methods (@BeforeEach, @Test, @AfterEach) "
+                            + "use the same AemContext type.");
+        }
+        return aemContext;
+    }
+
+    private AemContext getAemContext(ExtensionContext extensionContext) {
+        return getStore(extensionContext).get(extensionContext.getRequiredTestMethod(), AemContext.class);
+    }
+
+    private Store getStore(ExtensionContext context) {
+        return context.getStore(AEM_CONTEXT_NAMESPACE);
+    }
+
+    private AemContext createAndStoreAemContext(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Type aemContextType = getAemContextType(parameterContext, extensionContext);
+        if (aemContextType == AemContext.class) {
+            aemContextType = DEFAULT_AEM_CONTEXT_TYPE;
+        }
+        try {
+            Constructor constructor = ((Class<?>) aemContextType).getConstructor();
+            AemContext aemContext = (AemContext) constructor.newInstance();
+            aemContext.setUpContext();
+            storeAemContext(extensionContext, aemContext);
+            return aemContext;
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not create AemContext instance", e);
+        }
+    }
+
+    private Type getAemContextType(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        if (isAbstractAemContext(parameterContext)) {
+            return getAemContextTypeFromTestMethod(extensionContext);
+        } else {
+            return parameterContext.getParameter().getType();
+        }
+    }
+
+    private boolean isAbstractAemContext(ParameterContext parameterContext) {
+        return parameterContext.getParameter().getType().equals(AemContext.class);
+    }
+
+    private void storeAemContext(ExtensionContext extensionContext, AemContext aemContext) {
+        getStore(extensionContext).put(extensionContext.getRequiredTestMethod(), aemContext);
+    }
+
+    private void removeAemContext(ExtensionContext extensionContext, AemContext aemContext) {
+        aemContext.tearDownContext();
+        getStore(extensionContext).remove(extensionContext.getRequiredTestMethod());
+    }
+
+    private boolean paramIsNotInstanceOfExistingContext(ParameterContext parameterContext, AemContext aemContext) {
+        return !parameterContext.getParameter().getType().isInstance(aemContext);
+    }
+
+    private Class<?> getAemContextTypeFromTestMethod(ExtensionContext extensionContext) {
+        return extensionContext.getTestMethod()
+                .map(Method::getParameterTypes)
+                .map(Arrays::asList)
+                .orElse(emptyList())
+                .stream()
+                .filter(type -> type.isInstance(AemContext.class))
+                .findFirst()
+                .orElse(DEFAULT_AEM_CONTEXT_TYPE);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        AemContext aemContext = getAemContext(extensionContext);
+        if (aemContext != null) {
+            removeAemContext(extensionContext, aemContext);
+        }
+    }
+
+}

--- a/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/JcrMockAemContext.java
+++ b/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/JcrMockAemContext.java
@@ -1,0 +1,11 @@
+package io.wcm.testing.mock.aem.junit5;
+
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+
+public class JcrMockAemContext extends AemContext {
+
+    public JcrMockAemContext() {
+        setResourceResolverType(ResourceResolverType.JCR_MOCK);
+    }
+
+}

--- a/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/JcrOakAemContext.java
+++ b/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/JcrOakAemContext.java
@@ -1,0 +1,11 @@
+package io.wcm.testing.mock.aem.junit5;
+
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+
+public class JcrOakAemContext extends AemContext {
+
+    public JcrOakAemContext() {
+        setResourceResolverType(ResourceResolverType.JCR_OAK);
+    }
+
+}

--- a/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/ResourceResolverMockAemContext.java
+++ b/aem-mock/src/main/java/io/wcm/testing/mock/aem/junit5/ResourceResolverMockAemContext.java
@@ -1,0 +1,11 @@
+package io.wcm.testing.mock.aem.junit5;
+
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+
+public class ResourceResolverMockAemContext extends AemContext {
+
+    public ResourceResolverMockAemContext() {
+        setResourceResolverType(ResourceResolverType.RESOURCERESOLVER_MOCK);
+    }
+
+}

--- a/aem-mock/src/test/java/io/wcm/testing/mock/aem/junit5/AemContextTest.java
+++ b/aem-mock/src/test/java/io/wcm/testing/mock/aem/junit5/AemContextTest.java
@@ -1,0 +1,20 @@
+package io.wcm.testing.mock.aem.junit5;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class AemContextTest {
+
+    @BeforeEach
+    void setUp(ResourceResolverMockAemContext context) {
+        // TODO
+    }
+
+    @Test
+    void test(JcrMockAemContext context) {
+        // TODO
+    }
+
+}


### PR DESCRIPTION
This is some kind of draft for feature described here: https://wcm-io.atlassian.net/browse/WTES-29.
Few words about how it works:
If test lifecycle method (`@BeforeEach`, `@Test`, `@AfterEach`) has `AemContext` parameter, then it will be created if not exists, or taken from context store. Parameter can be of `AemContext` abstract type - default context which is `ResourceResolverMockAemContext` will be created in such case. All 3 lifecycle methods must have matching context parameter. In case we inject `JcrOakAemContext` in `@BeforeEach` and `JcrMockAemContext` in `@Test`, then exception will be thrown with hint for developer what is wrong (it could be improved to print it in more readable and easier to understand way).