### PR TITLE
Facilitate @ScriptVariable injection for currentPage

### DIFF
--- a/aem-mock/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/aem-mock/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.context.SlingContextImpl;
 import org.osgi.annotation.versioning.ConsumerType;
@@ -151,6 +152,7 @@ public class AemContextImpl extends SlingContextImpl {
     if (page != null) {
       ComponentContext wcmComponentContext = new MockComponentContext(page, request());
       request.setAttribute(ComponentContext.CONTEXT_ATTR_NAME, wcmComponentContext);
+      addToSlingBindings( "currentPage", currentPage());
       currentResource(page.getContentResource());
       return page;
     }
@@ -159,6 +161,21 @@ public class AemContextImpl extends SlingContextImpl {
       currentResource((Resource)null);
       return null;
     }
+  }
+
+  /**
+   * Add a key, value pair to request (via {@link SlingBindings})
+   * so @ScriptVariable annotation will be injected in @Model
+   * @param key String
+   * @param value Object
+   */
+  private void addToSlingBindings(String key, Object value) {
+    SlingBindings slingBindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
+    if(slingBindings == null){
+      slingBindings = new SlingBindings();
+      request.setAttribute(SlingBindings.class.getName(), slingBindings);
+    }
+    slingBindings.put(key, value);
   }
 
   /**

--- a/aem-mock/src/test/java/io/wcm/testing/mock/aem/context/AemContextImplTest.java
+++ b/aem-mock/src/test/java/io/wcm/testing/mock/aem/context/AemContextImplTest.java
@@ -23,9 +23,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import io.wcm.testing.mock.aem.modelsautoreg.ScriptBindingsModel;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.testing.mock.sling.loader.ContentLoader;
 import org.junit.After;
 import org.junit.Before;
@@ -120,6 +123,17 @@ public class AemContextImplTest {
     String mappedPath = context.resourceResolver().map(contentRoot + "/toolbar/profiles");
     // unlike sling AEM does not define a default mapping from /content to /
     assertEquals(contentRoot + "/toolbar/profiles", mappedPath);
+  }
+
+  @Test
+  public void testInjectCurrentPageInComponent(){
+    SlingHttpServletRequest request = context.request();
+    context.currentPage(contentRoot + "/toolbar");
+
+    ScriptBindingsModel component = request.adaptTo(ScriptBindingsModel.class);
+
+    assertNotNull(component.getCurrentPage());
+    assertEquals(component.getCurrentPage().getPath(), contentRoot + "/toolbar");
   }
 
 }

--- a/aem-mock/src/test/java/io/wcm/testing/mock/aem/modelsautoreg/ScriptBindingsModel.java
+++ b/aem-mock/src/test/java/io/wcm/testing/mock/aem/modelsautoreg/ScriptBindingsModel.java
@@ -1,0 +1,38 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2018 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.wcm.testing.mock.aem.modelsautoreg;
+
+import com.day.cq.wcm.api.Page;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+
+/**
+ * For testing Sling Bindings support.
+ */
+
+@Model(adaptables = SlingHttpServletRequest.class)
+public interface ScriptBindingsModel {
+
+    @ScriptVariable
+    public Page getCurrentPage();
+
+}


### PR DESCRIPTION
We had issues with injecting currentPage with a @ScriptVariable annotation using the AEMContext in a test case.
The model we are adapting to resembles the ScriptBindingsModel class below.

We investigated how the injection occurs on a AEM 6.3 server and found it is retrieved from a "ScriptBindings" object stored in the request attributes.

The current implementation only stores the currentPage in the ComponentContext, and the @ScriptVariable is unable to resolve this. 

We added a test for this scenario and added implementation to resolve the issue.