### PR TITLE
json-export-for-container-sling-model

### DIFF
--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import javax.script.SimpleBindings;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -250,7 +252,7 @@ public class AemContextImpl extends SlingContextImpl {
   protected @Nullable Object resolveSlingBindingProperty(@NotNull String property) {
     Object result = super.resolveSlingBindingProperty(property);
     if (result == null) {
-      result = MockAemSlingBindings.resolveSlingBindingProperty(this, property);
+      result = MockAemSlingBindings.resolveSlingBindingProperty(this, property, new SimpleBindings());
     }
     return result;
   }

--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/MockAemBindingsValuesProvider.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/MockAemBindingsValuesProvider.java
@@ -53,7 +53,7 @@ class MockAemBindingsValuesProvider implements BindingsValuesProvider {
   }
 
   private void putProperty(Bindings bindings, String key) {
-    Object value = MockAemSlingBindings.resolveSlingBindingProperty(context, key);
+    Object value = MockAemSlingBindings.resolveSlingBindingProperty(context, key, bindings);
     if (value != null) {
       bindings.put(key, value);
     }

--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/MockAemSlingBindings.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/MockAemSlingBindings.java
@@ -19,11 +19,14 @@
  */
 package io.wcm.testing.mock.aem.context;
 
+import javax.script.Bindings;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.scripting.SlingBindings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -86,8 +89,7 @@ final class MockAemSlingBindings {
     // static methods only
   }
 
-  static @Nullable Object resolveSlingBindingProperty(@NotNull AemContextImpl context, @NotNull String property) {
-
+  static @Nullable Object resolveSlingBindingProperty(@NotNull AemContextImpl context, @NotNull String property, @NotNull Bindings previous) {
     if (StringUtils.equals(property, SlingBindingsProperty.COMPONENT_CONTEXT.key)) {
       return getWcmComponentContext(context);
     }
@@ -110,7 +112,7 @@ final class MockAemSlingBindings {
       return getPageProperties(context);
     }
     if (StringUtils.equals(property, SlingBindingsProperty.COMPONENT.key())) {
-      return getComponent(context);
+      return getComponent(context, previous);
     }
     if (StringUtils.equals(property, SlingBindingsProperty.DESIGNER.key())) {
       return getDesigner(context);
@@ -124,7 +126,6 @@ final class MockAemSlingBindings {
     if (StringUtils.equals(property, SlingBindingsProperty.CURRENT_STYLE.key())) {
       return getStyle(context);
     }
-
     return null;
   }
 
@@ -161,8 +162,8 @@ final class MockAemSlingBindings {
     return null;
   }
 
-  private static Component getComponent(AemContextImpl context) {
-    Resource resource = context.currentResource();
+  private static Component getComponent(AemContextImpl context, Bindings previous) {
+    Resource resource = (Resource) previous.getOrDefault(SlingBindings.RESOURCE, context.currentResource());
     if (resource != null) {
       return WCMUtils.getComponent(resource);
     }


### PR DESCRIPTION
- fix JSON export for items of a container model

Background: 
When testing the JSON export of an AEM container component (e.g. Carousel/Tabs) [0], the JSON `:items` object representing the container items is empty because the Sling model returned by `modelFactory.getModelFromWrappedRequest(request, child, modelClass);` in the JUnit tests is null [1].

[0] https://github.com/adobe/aem-core-wcm-components/pull/365/files#diff-e63520711a6e0f55f971d0eac00dbb55R86
[1] https://github.com/adobe/aem-core-wcm-components/pull/365/files#diff-8913744157584c8aa2b63545f03d6879R131
