### PR TITLE
Bug/mock tag manager subtree search var

### DIFF
--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockTagManager.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockTagManager.java
@@ -403,7 +403,7 @@ public final class MockTagManager implements TagManager {
         CollectionUtils.addAll(searchResources, searchResource.listChildren());
       }
 
-      String[] tags = resource.getValueMap().get(TagConstants.PN_TAGS, String[].class);
+      String[] tags = searchResource.getValueMap().get(TagConstants.PN_TAGS, String[].class);
       if (tags == null) {
         continue;
       }

--- a/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockTagManagerTest.java
+++ b/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockTagManagerTest.java
@@ -244,6 +244,18 @@ public class MockTagManagerTest {
     assertNull(tag);
   }
 
+  @Test
+  public void testGetTagsForSubtree() {
+    Tag[] tags = tagManager.getTagsForSubtree(rootPage.adaptTo(Resource.class), false);
+
+    assertNotNull(tags);
+    assertEquals(4, tags.length);
+    assertTrue(containsPath(tags, tagRoot + "/default/tagA"));
+    assertTrue(containsPath(tags, tagRoot + "/wcmio/aem/api"));
+    assertTrue(containsPath(tags, tagRoot + "/default/tagB"));
+    assertTrue(containsPath(tags, tagRoot + "/wcmio/nondescript"));
+  }
+
   private boolean containsPath(Tag[] tags, String path) {
     for (Tag tag : tags) {
       if (StringUtils.equals(tag.getPath(), path)) {


### PR DESCRIPTION
`MockTagManager`'s `collectResourceTags` method is fetching tags from the `resource` variable, rather than the queued `searchResource` variable in the loop.

Adjusting the referenced variable properly returns tags found in the resource subtree.