### PR TITLE
 Updating ContentFragment getElement method functionality

### DIFF
--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockContentFragment.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockContentFragment.java
@@ -157,7 +157,24 @@ class MockContentFragment extends MockContentFragment_Versionable implements Con
       }
     }
     else if (modelElementsResource != null) {
-      Resource resource = modelElementsResource.getChild(elementName);
+      //Fixing according to ContentFragment documentation for getElement method:
+      //Parameters:
+      //elementName - The name of the element; null or empty string for the "main" or "master" element
+      //See https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/javadoc/com/adobe/cq/dam/cfm/ContentFragment.html#getElement-java.lang.String-
+
+      Resource resource = null;
+      String validatedElementName = elementName;
+      if(elementName == null || elementName.equals("")) {
+    	validatedElementName = "main";
+    	resource = modelElementsResource.getChild(elementName);
+    	if (resource == null) {
+          validatedElementName = "master";
+          resource = modelElementsResource.getChild(elementName);
+        }
+      } else {
+    	  resource = modelElementsResource.getChild(validatedElementName);
+      }
+      
       if (resource != null) {
         return new MockContentFragment_ContentElement_Text(this, resource);
       }

--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockContentFragment.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockContentFragment.java
@@ -157,22 +157,17 @@ class MockContentFragment extends MockContentFragment_Versionable implements Con
       }
     }
     else if (modelElementsResource != null) {
-      //Fixing according to ContentFragment documentation for getElement method:
-      //Parameters:
-      //elementName - The name of the element; null or empty string for the "main" or "master" element
-      //See https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/javadoc/com/adobe/cq/dam/cfm/ContentFragment.html#getElement-java.lang.String-
-
       Resource resource = null;
-      String validatedElementName = elementName;
+      String checkedElementName = elementName;
       if(elementName == null || elementName.equals("")) {
-    	validatedElementName = "main";
-    	resource = modelElementsResource.getChild(elementName);
+    	checkedElementName = "main";
+    	resource = modelElementsResource.getChild(checkedElementName);
     	if (resource == null) {
-          validatedElementName = "master";
-          resource = modelElementsResource.getChild(elementName);
+        checkedElementName = "master";
+          resource = modelElementsResource.getChild(checkedElementName);
         }
       } else {
-    	  resource = modelElementsResource.getChild(validatedElementName);
+    	  resource = modelElementsResource.getChild(checkedElementName);
       }
       
       if (resource != null) {

--- a/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockContentFragmentTest.java
+++ b/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockContentFragmentTest.java
@@ -115,6 +115,16 @@ public class MockContentFragmentTest {
     assertTrue(cf.getElements().hasNext());
     assertTrue(cf.hasElement("main"));
 
+    //getElement with null param should act as if "main" param was passed
+    ContentElement contentElementEmptyParam = cf.getElement("");
+    assertEquals("<p>Text</p>", contentElementEmptyParam.getContent());
+    assertEquals("text/html", contentElementEmptyParam.getContentType());
+    
+    //getElement with null param should act as if "main" param was passed
+    ContentElement contentElementNullParam = cf.getElement(null);
+    assertEquals("<p>Text</p>", contentElementNullParam.getContent());
+    assertEquals("text/html", contentElementNullParam.getContentType());
+
     ContentElement contentElement = cf.getElement("main");
     assertEquals("<p>Text</p>", contentElement.getContent());
     assertEquals("text/html", contentElement.getContentType());


### PR DESCRIPTION
Thanks for this super useful project!
I ran into an issue while working on testing my contentFragment, so I fixed it according to the ContentFragment documentation for getElement method:

Parameters:
elementName - The name of the element; *null or empty string for the "main" or "master" element*

See https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/javadoc/com/adobe/cq/dam/cfm/ContentFragment.html#getElement-java.lang.String-

Regards!