### PR TITLE
WTES-47: Implement basic ComponentContext hierarchy  

### DIFF
--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockComponentContext.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockComponentContext.java
@@ -154,17 +154,17 @@ public final class MockComponentContext implements ComponentContext {
 
   @Override
   public ComponentContext getParent() {
-    throw new UnsupportedOperationException();
+    return null;
   }
 
   @Override
   public ComponentContext getRoot() {
-    throw new UnsupportedOperationException();
+    return this;
   }
 
   @Override
   public boolean isRoot() {
-    throw new UnsupportedOperationException();
+    return true;
   }
 
   @Override

--- a/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockComponentContextTest.java
+++ b/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockComponentContextTest.java
@@ -76,6 +76,17 @@ public class MockComponentContextTest {
   }
 
   @Test
+  public void testGetRoot() {
+    assertTrue(underTest.isRoot());
+    assertSame(underTest, underTest.getRoot());
+  }
+
+  @Test
+  public void testGetParent() {
+    assertNull(underTest.getParent());
+  }
+
+  @Test
   public void testGetPage() {
     assertEquals(page.getPath(), underTest.getPage().getPath());
   }


### PR DESCRIPTION
Implemented getRoot(), isRoot() and getParent() of MockComponentContext considering a single root ComponentContext being provided by AemContext

fixes WTES-47