### PR TITLE
Add Language manager service

### DIFF
--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockLanguageManager.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockLanguageManager.java
@@ -1,0 +1,268 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2020 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.testing.mock.aem;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.wcm.api.PageManager;
+import com.day.text.Text;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+import com.day.cq.commons.Language;
+import com.day.cq.commons.LanguageUtil;
+import com.day.cq.wcm.api.LanguageManager;
+import com.day.cq.wcm.api.Page;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = LanguageManager.class)
+@ProviderType
+public class MockLanguageManager implements LanguageManager {
+
+    @Override
+    public String getIsoCountry(final Locale locale) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    public Map<Locale, Info> getAdjacentInfo(final ResourceResolver resourceResolver, final String path) {
+        return Optional.ofNullable(getAdjacentLanguageInfo(resourceResolver, path))
+                .map(Map::entrySet)
+                .map(Collection::stream)
+                .map(entries -> entries.collect(toLinkedMap(i -> i.getKey().getLocale(), Map.Entry::getValue)))
+                .orElse(null);
+    }
+
+    @Override
+    public Map<Language, Info> getAdjacentLanguageInfo(final ResourceResolver resourceResolver, final String path) {
+        return Optional.ofNullable(LanguageUtil.getLanguageRoot(path))
+                .map(root -> path.substring(root.length()))
+                .map(relPath -> relPath.startsWith("/") ? relPath.substring(1) : relPath)
+                .map(relPath ->
+                        this.getLanguageRootStream(resourceResolver, path)
+                                .map(info -> info.getChild(relPath, resourceResolver))
+                                .collect(toLinkedMap(InfoImpl::getLanguage, i -> (Info) i)))
+                .orElse(null);
+    }
+
+    @Override
+    public Locale getLanguage(final Resource resource) {
+        return this.getLanguage(resource, true);
+    }
+
+    @Override
+    public Language getCqLanguage(final Resource resource) {
+        return this.getCqLanguage(resource, true);
+    }
+
+    @Override
+    public Locale getLanguage(final Resource resource, final boolean respectContent) {
+        return Optional.ofNullable(getCqLanguage(resource, respectContent))
+                .map(Language::getLocale)
+                .orElse(null);
+    }
+
+    @Override
+    public Language getCqLanguage(final Resource resource, final boolean respectContent) {
+        Optional<Page> page = Optional.ofNullable(resource.getResourceResolver().adaptTo(PageManager.class))
+                .map(pm -> pm.getContainingPage(resource));
+
+        if (respectContent) {
+            return page
+                    .map(Page::getContentResource)
+                    .map(HierarchyNodeInheritanceValueMap::new)
+                    .map(vm -> vm.getInherited(JcrConstants.JCR_LANGUAGE, String.class))
+                    .map(LanguageUtil::getLanguage)
+                    .orElseGet(() -> this.getCqLanguage(resource, false));
+        }
+
+        return page
+                .map(Page::getPath)
+                .map(LanguageUtil::getLanguageRoot)
+                .map(Text::getName)
+                .map(Language::new)
+                .orElse(null);
+    }
+
+    @Override
+    public Page getLanguageRoot(final Resource resource) {
+        return Optional.ofNullable(LanguageUtil.getLanguageRoot(resource.getPath()))
+                .map(resource.getResourceResolver()::getResource)
+                .map(res -> res.adaptTo(Page.class))
+                .orElse(null);
+    }
+
+    @Override
+    public Collection<Locale> getLanguages(final ResourceResolver resourceResolver, final String path) {
+        return this.getCqLanguages(resourceResolver, path).stream()
+                .map(Language::getLocale)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<Language> getCqLanguages(final ResourceResolver resourceResolver, final String path) {
+        return this.getLanguageRootStream(resourceResolver, path)
+                .map(InfoImpl::getLanguage)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<Page> getLanguageRoots(final ResourceResolver resourceResolver, final String path) {
+        return this.getLanguageRootStream(resourceResolver, path)
+                .map(InfoImpl::getResource)
+                .filter(Objects::nonNull)
+                .map(res -> res.adaptTo(Page.class))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private Stream<InfoImpl> getLanguageRootStream(final ResourceResolver resourceResolver, final String path) {
+        return Optional.ofNullable(LanguageUtil.getLanguageRoot(path))
+                .map(resourceResolver::getResource)
+                .map(Resource::getParent)
+                .map(Resource::listChildren)
+                .map(childIterator -> StreamSupport.stream(((Iterable<Resource>) () -> childIterator).spliterator(), false))
+                .orElseGet(Stream::empty)
+                .filter(res -> Objects.nonNull(LanguageUtil.getLanguage(res.getName())))
+                .map(res -> new InfoImpl(res.getPath(), res, LanguageUtil.getLanguage(res.getName())));
+    }
+
+    @Override
+    public Tree compareLanguageTrees(final ResourceResolver resourceResolver, final String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Collector for collecting a stream to a linked hash map.
+     *
+     * @param keyMapper   A mapping function to produce keys.
+     * @param valueMapper A mapping function to produce values.
+     * @param <T>         The type of input elements to the reduction operation.
+     * @param <K>         The output type of the key mapping function.
+     * @param <U>         The output type of the value mapping function.
+     * @return A Collector which collects elements into a LinkedHashMap whose keys are the result of applying a key
+     * mapping function to the input elements, and whose values are the result of applying a value mapping function to
+     * all input elements equal to the key and combining them using the merge function
+     */
+    private static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedMap(
+            final Function<? super T, ? extends K> keyMapper, final Function<? super T, ? extends U> valueMapper) {
+        return Collectors.toMap(
+                keyMapper,
+                valueMapper,
+                (u, v) -> {
+                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                },
+                LinkedHashMap::new
+        );
+    }
+
+    private static final class InfoImpl implements LanguageManager.Info {
+        private final String path;
+        private final Resource resource;
+        private final Language language;
+
+        public InfoImpl(@NotNull final String path, @Nullable final Resource resource, @NotNull final Language language) {
+            this.path = path;
+            this.resource = resource;
+            this.language = language;
+        }
+
+        @Override
+        public String getPath() {
+            return this.path;
+        }
+
+        @Override
+        public boolean exists() {
+            return this.resource != null;
+        }
+
+        @Override
+        public boolean hasContent() {
+            return Optional.ofNullable(this.resource)
+                    .map(res -> resource.getChild(JcrConstants.JCR_CONTENT))
+                    .isPresent();
+        }
+
+        @Override
+        public long getLastModified() {
+            return Optional.ofNullable(this.resource)
+                    .map(res -> resource.getChild(JcrConstants.JCR_CONTENT))
+                    .map(Resource::getValueMap)
+                    .map(vm -> vm.get(JcrConstants.JCR_LASTMODIFIED, Long.class))
+                    .orElse(0L);
+        }
+
+        /**
+         * The resource located at {@link #getPath()}, if it exists.
+         *
+         * @return The resource.
+         */
+        @Nullable
+        private Resource getResource() {
+            return this.resource;
+        }
+
+        /**
+         * Get the language.
+         *
+         * @return The language.
+         */
+        @NotNull
+        private Language getLanguage() {
+            return this.language;
+        }
+
+        /**
+         * Gets the InfoImpl for a child resource under the current InfoImpl's path.
+         * <p>
+         * This constructs a new InfoImpl using the path getPath() + / + relPath.
+         *
+         * @param relPath          Path relative to the current path.
+         * @param resourceResolver A resource resolver.
+         * @return A new InfoImpl for the resource specified at relPath.
+         */
+        private InfoImpl getChild(@NotNull final String relPath, @NotNull final ResourceResolver resourceResolver) {
+            if (relPath.isEmpty()) {
+                return this;
+            }
+            String path = String.join("/", this.path, relPath);
+            Resource child = resourceResolver.getResource(path);
+            return new InfoImpl(path, child, this.getLanguage());
+        }
+    }
+}
+

--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -44,6 +44,7 @@ import com.day.cq.wcm.commons.WCMUtils;
 import io.wcm.testing.mock.aem.MockAemAdapterFactory;
 import io.wcm.testing.mock.aem.MockComponentContext;
 import io.wcm.testing.mock.aem.MockContentPolicyStorage;
+import io.wcm.testing.mock.aem.MockLanguageManager;
 import io.wcm.testing.mock.aem.MockLayerAdapterFactory;
 import io.wcm.testing.mock.aem.MockPageManagerFactory;
 import io.wcm.testing.mock.aem.builder.ContentBuilder;
@@ -76,6 +77,7 @@ public class AemContextImpl extends SlingContextImpl {
     registerInjectActivateService(new MockAemBindingsValuesProvider(),
         MockAemBindingsValuesProvider.PROPERTY_CONTEXT, this);
     registerInjectActivateService(new MockPageManagerFactory());
+    registerInjectActivateService(new MockLanguageManager());
 
     // Granite resource collection manager
     registerInjectActivateService(new MockResourceCollectionManager());

--- a/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockLanguageManagerTest.java
+++ b/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockLanguageManagerTest.java
@@ -1,0 +1,253 @@
+package io.wcm.testing.mock.aem;
+
+import com.day.cq.commons.Language;
+import com.day.cq.wcm.api.LanguageManager;
+import com.day.cq.wcm.api.Page;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.testing.mock.sling.loader.ContentLoader;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MockLanguageManagerTest {
+
+    private static final String SITE_ROOT = "/content/sample";
+    private static final String ENGLISH_HOMEPAGE = String.join("/", SITE_ROOT, "en");
+    private static final String FRENCH_HOMEPAGE = String.join("/", SITE_ROOT, "fr");
+
+
+    // Run all unit tests for each resource resolver types listed here
+    @Rule
+    public AemContext context = TestAemContext.newAemContext();
+
+    @Before
+    public void setUp() {
+        ContentLoader contentLoader = this.context.load();
+        contentLoader.json("/json-import-samples/language-content.json", SITE_ROOT);
+    }
+
+    @Test
+    public void getLanguage() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Locale englishLocale = languageManager.getLanguage(Objects.requireNonNull(context.resourceResolver().getResource(ENGLISH_HOMEPAGE + "/subpage/jcr:content")));
+        assertNotNull(englishLocale);
+        assertEquals(Locale.ENGLISH, englishLocale);
+
+        Locale frenchLocale = languageManager.getLanguage(Objects.requireNonNull(context.resourceResolver().getResource(FRENCH_HOMEPAGE + "/subpage/jcr:content")));
+        assertNotNull(frenchLocale);
+        assertEquals(Locale.JAPANESE, frenchLocale);
+
+        Locale rootLocale = languageManager.getLanguage(Objects.requireNonNull(context.resourceResolver().getResource(SITE_ROOT)));
+        assertNull(rootLocale);
+    }
+
+    @Test
+    public void getCqLanguage() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Language englishLocale = languageManager.getCqLanguage(Objects.requireNonNull(context.resourceResolver().getResource(ENGLISH_HOMEPAGE + "/subpage/jcr:content")), false);
+        assertNotNull(englishLocale);
+        assertEquals(Locale.ENGLISH, englishLocale.getLocale());
+
+        Language frenchLocale = languageManager.getCqLanguage(Objects.requireNonNull(context.resourceResolver().getResource(FRENCH_HOMEPAGE + "/subpage/jcr:content")), false);
+        assertNotNull(frenchLocale);
+        assertEquals(Locale.FRENCH, frenchLocale.getLocale());
+
+        Language rootLocale = languageManager.getCqLanguage(Objects.requireNonNull(context.resourceResolver().getResource(SITE_ROOT)), false);
+        assertNull(rootLocale);
+    }
+
+    @Test
+    public void getCqLanguage_respectContent() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Language englishLocale = languageManager.getCqLanguage(Objects.requireNonNull(context.resourceResolver().getResource(ENGLISH_HOMEPAGE + "/subpage/jcr:content")));
+        assertNotNull(englishLocale);
+        assertEquals(Locale.ENGLISH, englishLocale.getLocale());
+
+        // when respecting content the "fr" site should present as "ja"
+        Language frenchLocale = languageManager.getCqLanguage(Objects.requireNonNull(context.resourceResolver().getResource(FRENCH_HOMEPAGE + "/subpage/jcr:content")));
+        assertNotNull(frenchLocale);
+        assertEquals(Locale.JAPANESE, frenchLocale.getLocale());
+
+        Language rootLocale = languageManager.getCqLanguage(Objects.requireNonNull(context.resourceResolver().getResource(SITE_ROOT)));
+        assertNull(rootLocale);
+    }
+
+    @Test
+    public void getLanguageRoot() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Page englishLanguageRoot = languageManager.getLanguageRoot(Objects.requireNonNull(context.resourceResolver().getResource(ENGLISH_HOMEPAGE + "/subpage/jcr:content")));
+        assertNotNull(englishLanguageRoot);
+        assertEquals(ENGLISH_HOMEPAGE, englishLanguageRoot.getPath());
+
+        Page frenchLanguageRoot = languageManager.getLanguageRoot(Objects.requireNonNull(context.resourceResolver().getResource(FRENCH_HOMEPAGE + "/subpage/jcr:content")));
+        assertNotNull(frenchLanguageRoot);
+        assertEquals(FRENCH_HOMEPAGE, frenchLanguageRoot.getPath());
+    }
+
+    @Test
+    public void getLanguageRoots() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Collection<Page> roots = languageManager.getLanguageRoots(context.resourceResolver(), ENGLISH_HOMEPAGE + "/subpage/jcr:content");
+        assertNotNull(roots);
+        assertArrayEquals(new String[] {ENGLISH_HOMEPAGE, FRENCH_HOMEPAGE}, roots.stream().map(Page::getPath).toArray());
+
+        Collection<Page> roots2 = languageManager.getLanguageRoots(context.resourceResolver(), FRENCH_HOMEPAGE + "/subpage/jcr:content");
+        assertNotNull(roots2);
+        assertArrayEquals(new String[] {ENGLISH_HOMEPAGE, FRENCH_HOMEPAGE}, roots2.stream().map(Page::getPath).toArray());
+
+        //NOTE: this situation causes an NPE in current LanguageManager implementation
+        /* Collection<Page> roots3 = languageManager.getLanguageRoots(context.resourceResolver(), "/does/not/exist");
+        assertNotNull(roots3);
+        assertArrayEquals(new Page[] {}, roots3.toArray(new Page[0]));
+        */
+
+        Collection<Page> roots4 = languageManager.getLanguageRoots(context.resourceResolver(), SITE_ROOT);
+        assertNotNull(roots4);
+        assertArrayEquals(new Page[] {}, roots4.toArray(new Page[0]));
+
+        Collection<Page> nullPath = languageManager.getLanguageRoots(context.resourceResolver(), null);
+        assertArrayEquals(new Page[] {}, nullPath.toArray(new Page[0]));
+
+        Collection<Page> rootPath = languageManager.getLanguageRoots(context.resourceResolver(), "/");
+        assertArrayEquals(new Page[] {}, rootPath.toArray(new Page[0]));
+    }
+
+    @Test
+    public void getLanguages() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Collection<Locale> locales = languageManager.getLanguages(context.resourceResolver(), ENGLISH_HOMEPAGE + "/subpage/jcr:content");
+        assertNotNull(locales);
+        assertArrayEquals(new Locale[] {Locale.ENGLISH, Locale.FRENCH}, locales.toArray(new Locale[0]));
+
+        Collection<Locale> locales2 = languageManager.getLanguages(context.resourceResolver(), FRENCH_HOMEPAGE + "/subpage/jcr:content");
+        assertNotNull(locales2);
+        assertArrayEquals(new Locale[] {Locale.ENGLISH, Locale.FRENCH}, locales2.toArray(new Locale[0]));
+
+        Collection<Locale> locales3 = languageManager.getLanguages(context.resourceResolver(), "/does/not/exist");
+        assertNotNull(locales3);
+        assertArrayEquals(new Locale[] {}, locales3.toArray(new Locale[0]));
+
+        Collection<Locale> locales4 = languageManager.getLanguages(context.resourceResolver(), SITE_ROOT);
+        assertNotNull(locales4);
+        assertArrayEquals(new Locale[] {}, locales4.toArray(new Locale[0]));
+    }
+
+    @Test
+    public void getCqLanguages() {
+        LanguageManager languageManager = new MockLanguageManager();
+        Collection<Language> languages = languageManager.getCqLanguages(context.resourceResolver(), ENGLISH_HOMEPAGE + "/subpage/jcr:content");
+        assertNotNull(languages);
+        assertArrayEquals(new Locale[] {Locale.ENGLISH, Locale.FRENCH}, languages.stream().map(Language::getLocale).toArray());
+
+        Collection<Language> languages2 = languageManager.getCqLanguages(context.resourceResolver(), FRENCH_HOMEPAGE + "/subpage/jcr:content");
+        assertNotNull(languages2);
+        assertArrayEquals(new Locale[] {Locale.ENGLISH, Locale.FRENCH}, languages2.stream().map(Language::getLocale).toArray());
+
+        Collection<Language> languages3 = languageManager.getCqLanguages(context.resourceResolver(), "/does/not/exist");
+        assertNotNull(languages3);
+        assertArrayEquals(new Locale[] {}, languages3.stream().map(Language::getLocale).toArray());
+
+        Collection<Language> languages4 = languageManager.getCqLanguages(context.resourceResolver(), SITE_ROOT);
+        assertNotNull(languages4);
+        assertArrayEquals(new Locale[] {}, languages4.stream().map(Language::getLocale).toArray());
+    }
+
+    @Test
+    public void getAdjacentLanguageInfo() {
+        LanguageManager languageManager = new MockLanguageManager();
+        // have to use a page path, doesn't work on a non-page resource
+        Map<Language, LanguageManager.Info> adjacentLanguageInfo = languageManager.getAdjacentLanguageInfo(context.resourceResolver(), ENGLISH_HOMEPAGE + "/subpage2");
+        assertNotNull(adjacentLanguageInfo);
+        assertArrayEquals(new Locale[] {Locale.ENGLISH, Locale.FRENCH}, adjacentLanguageInfo.keySet().stream().map(Language::getLocale).toArray());
+
+        LanguageManager.Info englishInfo = adjacentLanguageInfo.entrySet().stream()
+                .filter(e -> e.getKey().getLocale().equals(Locale.ENGLISH))
+                .map(Map.Entry::getValue)
+                .findFirst().orElse(null);
+        assertNotNull(englishInfo);
+        assertEquals(ENGLISH_HOMEPAGE + "/subpage2", englishInfo.getPath());
+        // this, in theory, should return the value, but it only seems to return 0
+        assertEquals(0L, englishInfo.getLastModified());
+        assertTrue(englishInfo.exists());
+        assertTrue(englishInfo.hasContent());
+
+
+        LanguageManager.Info frenchInfo = adjacentLanguageInfo.entrySet().stream()
+                .filter(e -> e.getKey().getLocale().equals(Locale.FRENCH))
+                .map(Map.Entry::getValue)
+                .findFirst().orElse(null);
+        assertNotNull(frenchInfo);
+        assertEquals(FRENCH_HOMEPAGE + "/subpage2", frenchInfo.getPath());
+        // this, in theory, should return the value, but it only seems to return 0
+        assertEquals(0L, frenchInfo.getLastModified());
+        assertFalse(frenchInfo.exists());
+        assertFalse(frenchInfo.hasContent());
+
+
+        Map<Language, LanguageManager.Info> nonExisting = languageManager.getAdjacentLanguageInfo(context.resourceResolver(), "/does/not/exist");
+        assertNull(nonExisting);
+
+        Map<Language, LanguageManager.Info> nullPath = languageManager.getAdjacentLanguageInfo(context.resourceResolver(), null);
+        assertNull(nullPath);
+
+        Map<Language, LanguageManager.Info> rootPath = languageManager.getAdjacentLanguageInfo(context.resourceResolver(), "/");
+        assertNull(rootPath);
+    }
+
+    @Test
+    public void getAdjacentInfo() {
+        LanguageManager languageManager = new MockLanguageManager();
+        // have to use a page path, doesn't work on a non-page resource
+        Map<Locale, LanguageManager.Info> adjacentInfo = languageManager.getAdjacentInfo(context.resourceResolver(), ENGLISH_HOMEPAGE + "/subpage2");
+        assertNotNull(adjacentInfo);
+        assertArrayEquals(new Locale[] {Locale.ENGLISH, Locale.FRENCH}, adjacentInfo.keySet().toArray());
+
+        LanguageManager.Info englishInfo = adjacentInfo.entrySet().stream()
+                .filter(e -> e.getKey().equals(Locale.ENGLISH))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+        assertNotNull(englishInfo);
+        assertEquals(ENGLISH_HOMEPAGE + "/subpage2", englishInfo.getPath());
+        // this, in theory, should return the value, but it only seems to return 0
+        assertEquals(0L, englishInfo.getLastModified());
+        assertTrue(englishInfo.exists());
+        assertTrue(englishInfo.hasContent());
+
+
+        LanguageManager.Info frenchInfo = adjacentInfo.entrySet().stream()
+                .filter(e -> e.getKey().equals(Locale.FRENCH))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+        assertNotNull(frenchInfo);
+        assertEquals(FRENCH_HOMEPAGE + "/subpage2", frenchInfo.getPath());
+        // this, in theory, should return the value, but it only seems to return 0
+        assertEquals(0L, frenchInfo.getLastModified());
+        assertFalse(frenchInfo.exists());
+        assertFalse(frenchInfo.hasContent());
+
+
+        Map<Locale, LanguageManager.Info> nonExisting = languageManager.getAdjacentInfo(context.resourceResolver(), "/does/not/exist");
+        assertNull(nonExisting);
+
+        Map<Locale, LanguageManager.Info> nullPath = languageManager.getAdjacentInfo(context.resourceResolver(), null);
+        assertNull(nullPath);
+
+        Map<Locale, LanguageManager.Info> rootPath = languageManager.getAdjacentInfo(context.resourceResolver(), "/");
+        assertNull(rootPath);
+    }
+}

--- a/aem-mock/core/src/test/resources/json-import-samples/language-content.json
+++ b/aem-mock/core/src/test/resources/json-import-samples/language-content.json
@@ -1,0 +1,107 @@
+{
+  "jcr:primaryType": "cq:Page",
+  "jcr:createdBy": "admin",
+  "jcr:created": "Thu Aug 07 2014 16:32:59 GMT+0200",
+  "jcr:content": {
+    "jcr:primaryType": "cq:PageContent",
+    "jcr:createdBy": "admin",
+    "jcr:title": "Sample Site",
+    "pageTitle": "Sample Site",
+    "cq:template": "/apps/sample/templates/homepage",
+    "jcr:created": "Thu Aug 07 2014 16:32:59 GMT+0200",
+    "jcr:lastModified": "Tue Apr 22 2014 11:11:24 GMT+0200",
+    "cq:lastModified": "Tue Apr 22 2014 11:11:24 GMT+0200",
+    "sling:resourceType": "sample/components/homepage",
+    "cq:designPath": "/etc/designs/sample",
+    "cq:lastModifiedBy": "admin"
+  },
+  "en": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:createdBy": "admin",
+    "jcr:created": "Thu Aug 07 2014 16:32:59 GMT+0200",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "jcr:createdBy": "admin",
+      "jcr:title": "English",
+      "cq:template": "/apps/sample/templates/homepage",
+      "jcr:created": "Thu Aug 07 2014 16:32:59 GMT+0200",
+      "jcr:lastModified": "Tue Apr 22 2014 11:11:24 GMT+0200",
+      "cq:lastModified": "Tue Apr 22 2014 11:11:24 GMT+0200",
+      "pageTitle": "English Homepage",
+      "sling:resourceType": "sample/components/homepage",
+      "cq:designPath": "/etc/designs/sample",
+      "cq:lastModifiedBy": "admin",
+      "cq:isLanguageRoot": true,
+      "jcr:language": "en"
+    },
+    "subpage": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:createdBy": "admin",
+      "jcr:created": "Thu Aug 07 2015 17:31:49 GMT+0200",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "jcr:createdBy": "admin",
+        "jcr:title": "Subpage",
+        "cq:template": "/apps/sample/templates/homepage",
+        "jcr:created": "Thu Aug 07 2015 17:31:49 GMT+0200",
+        "jcr:lastModified": "Tue Apr 22 2015 12:12:12 GMT+0200",
+        "cq:lastModified": "Tue Apr 22 2015 12:12:12 GMT+0200",
+        "pageTitle": "English Subpage",
+        "sling:resourceType": "sample/components/homepage"
+      }
+    },
+    "subpage2": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:createdBy": "admin",
+      "jcr:created": "Thu Aug 07 2015 17:31:49 GMT+0200",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "jcr:createdBy": "admin",
+        "jcr:title": "Subpage2",
+        "cq:template": "/apps/sample/templates/homepage",
+        "jcr:created": "Thu Aug 07 2017 17:31:49 GMT+0200",
+        "jcr:lastModified": "Tue Apr 22 2017 12:12:12 GMT+0200",
+        "cq:lastModified": "Tue Apr 22 2017 12:12:12 GMT+0200",
+        "pageTitle": "Subpage that exists only in English language",
+        "sling:resourceType": "sample/components/homepage"
+      }
+    }
+  },
+  "fr": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:createdBy": "admin",
+    "jcr:created": "Thu Aug 07 2014 16:32:59 GMT+0200",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "jcr:createdBy": "admin",
+      "jcr:title": "English",
+      "cq:template": "/apps/sample/templates/homepage",
+      "jcr:created": "Thu Aug 07 2014 16:32:59 GMT+0200",
+      "jcr:lastModified": "Tue Apr 22 2014 11:11:24 GMT+0200",
+      "cq:lastModified": "Tue Apr 22 2014 11:11:24 GMT+0200",
+      "pageTitle": "English Homepage",
+      "sling:resourceType": "sample/components/homepage",
+      "cq:designPath": "/etc/designs/sample",
+      "cq:lastModifiedBy": "admin",
+      "cq:isLanguageRoot": true,
+      "note": "LANGUAGE IS INTENTIONALLY NOT `fr`!",
+      "jcr:language": "ja"
+    },
+    "subpage": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:createdBy": "admin",
+      "jcr:created": "Thu Aug 07 2016 17:31:49 GMT+0200",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "jcr:createdBy": "admin",
+        "jcr:title": "Subpage",
+        "cq:template": "/apps/sample/templates/homepage",
+        "jcr:created": "Thu Aug 07 2016 17:31:49 GMT+0200",
+        "jcr:lastModified": "Thu Aug 07 2016 17:31:49 GMT+0200",
+        "cq:lastModified": "Tue Apr 22 2016 12:12:12 GMT+0200",
+        "pageTitle": "French Subpage",
+        "sling:resourceType": "sample/components/homepage"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adds `MockLanguageManager` which fulfils the `LanguageManager` service API.
- The implementation does not support `MockLanguageManager#getIsoCountry(Locale)` or `MockLanguageManager#compareLanguageTrees(ResourceResolver, String)` but all other features should be functional.