### PR TITLE
WTES-65: Correct behaviour of `MockComponent#getResourceType()`

### DIFF
--- a/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockComponent.java
+++ b/aem-mock/core/src/main/java/io/wcm/testing/mock/aem/MockComponent.java
@@ -19,10 +19,12 @@
  */
 package io.wcm.testing.mock.aem;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -38,6 +40,8 @@ import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentEditConfig;
 import com.day.cq.wcm.api.components.VirtualComponent;
+
+import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
 
 /**
  * Mock implementation of {@link Component}.
@@ -83,7 +87,14 @@ class MockComponent extends SlingAdaptable implements Component {
 
   @Override
   public String getResourceType() {
-    return resource.getResourceType();
+    return Optional.ofNullable(this.props.get(PROPERTY_RESOURCE_TYPE, String.class))
+            .orElseGet(() -> Optional.of(this.getPath())
+                    .filter(path -> path.startsWith("/"))
+                    .flatMap(path -> Arrays.stream(this.resource.getResourceResolver().getSearchPath())
+                            .filter(path::startsWith)
+                            .map(searchPath -> path.substring(searchPath.length()))
+                            .findFirst())
+                    .orElseGet(this::getPath));
   }
 
   @Override

--- a/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockComponentManagerTest.java
+++ b/aem-mock/core/src/test/java/io/wcm/testing/mock/aem/MockComponentManagerTest.java
@@ -21,7 +21,6 @@ package io.wcm.testing.mock.aem;
 
 import static com.day.cq.commons.jcr.JcrConstants.JCR_DESCRIPTION;
 import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
-import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
 import static com.day.cq.wcm.api.NameConstants.NN_HTML_TAG;
 import static com.day.cq.wcm.api.NameConstants.PN_COMPONENT_GROUP;
 import static com.day.cq.wcm.api.NameConstants.PN_NO_DECORATION;
@@ -31,7 +30,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
 import org.junit.Rule;
@@ -88,8 +86,7 @@ public class MockComponentManagerTest {
     assertEquals("myTitle", component.getTitle());
     assertEquals("myDescription", component.getDescription());
     assertEquals("myTitle", component.getProperties().get(JCR_TITLE, String.class));
-    assertTrue(StringUtils.isEmpty(component.getResourceType())
-        || StringUtils.equals(NT_UNSTRUCTURED, component.getResourceType()));
+    assertEquals("app1/components/c1", component.getResourceType());
     assertTrue(component.isAccessible());
     assertNotNull(component.adaptTo(Resource.class));
     assertEquals("myGroup", component.getComponentGroup());


### PR DESCRIPTION
Corrects the behaviour of `MockComponent#getResourceType()`
such that the component's underlying resource type is only returned
if the component resource explicitly has the property
`sling:resourceType` set. Otherwise the path of the underlying
resource is returned, minus the sling resolution path, if applicable.

Note: The change in this PR is based off my experience of how this should work - someone should double check that this behavior is actually correct.

----
refs WTES-56