### PR TITLE
remove unused oak-jcr dependency from compile class path

### DIFF
--- a/aem-mock/changes.xml
+++ b/aem-mock/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update to latest OSGi Mock and Sling Mock.
       </action>
+      <action type="update" dev="kwindszus">
+        Remove obsolete direct dependency to oak-jcr to make it compatible with latest sling-mock-oak.
+      </action>
       <action type="fix" dev="hkuijpers" issue="WTOOL-81">
         Fix expression that MockTag#getXPathSearchExpression produces, to be compliant with the XPATH spec.
       </action>

--- a/aem-mock/core/pom.xml
+++ b/aem-mock/core/pom.xml
@@ -104,11 +104,6 @@
       <artifactId>org.apache.sling.models.impl</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>oak-jcr</artifactId>
-      <scope>compile</scope>
-    </dependency>
 
     <!-- Has to be put first in dependencies to make sure updates oak/jcr dependencies
          are loaded before AEM API deps -->


### PR DESCRIPTION
Relevant in the context of https://github.com/apache/sling-org-apache-sling-testing-sling-mock-oak/pull/4/files